### PR TITLE
Add the byte array type

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -76,7 +76,7 @@ the caveat more precise.
 ### Terminology
 
 A Biscuit Datalog program contains *facts* and *rules*, which are made of *predicates*
-over the following types: *symbol*, *variable*, *integer*, *string* and *date*.
+over the following types: *symbol*, *variable*, *integer*, *string*, *byte array* and *date*.
 While Biscuit does not use a textual representation for storage, we will use
 one for this specification and for pretty printing of caveats.
 A *predicate* has the form `Predicate(v0, v1, ..., vn)`.
@@ -99,7 +99,8 @@ We will represent the various types as follows:
 - variable: `v?`
 - integer: `12`
 - string: `"hello"`
-- date in RFC 3339 format
+- byte array: `hex:01A2`
+- date in RFC 3339 format: `1985-04-12T23:20:50.52Z`
 
 As an example, assuming we have the following facts: `parent(#a, #b)`, `parent(#b, #c)`, `#parent(#c, #d)`.
 If we apply the rule `grandparent(x?, z?) <- parent(x?, y?), parent(y? z?)`, we will
@@ -121,7 +122,10 @@ An *integer* is a signed 64 bits integer. It supports the following constraints:
 lower or equal, larger or equal, equal, set inclusion and set exclusion.
 
 A *string* is a suite of UTF-8 characters. It supports the following constraints: prefix, suffix,
-equak, set inclusion, set exclusion, regular expression.
+equal, set inclusion, set exclusion, regular expression.
+
+A *byte array* is a suite of bytes. It supports the following constraints: equal, set inclusion,
+set exclusion.
 
 A *date* is a 64 bit unsigned integer representing a TAI64. It supports the following constraints:
 before, after.
@@ -348,6 +352,7 @@ ID = Symbol | Variable | Integer | Str | Date
 Variable = u32
 Integer = i64
 Str = string
+Bytes = [u8]
 Date = date
 ```
 
@@ -456,6 +461,24 @@ NotIn {
 
 Regex {
   bound: string
+}
+```
+
+Bytes constraints:
+
+```
+BytesConstraint = Equal | In | NotIn
+
+Equal {
+  bound: string
+}
+
+In {
+  set: [string]
+}
+
+NotIn {
+  set: [string]
 }
 ```
 

--- a/SPECIFICATIONS.md
+++ b/SPECIFICATIONS.md
@@ -61,9 +61,9 @@ simplifies its implementation and makes the caveat more precise.
 
 A Biscuit Datalog program contains *facts* and *rules*, which are made of
 *predicates* over the following types: *symbol*, *variable*, *integer*,
-*string* and *date*. While Biscuit does not use a textual representation for
-storage, we will use one for this specification and for pretty printing of
-caveats.
+*string*, *byte array* and *date*. While Biscuit does not use a textual
+representation for storage, we will use one for this specification and
+for pretty printing of caveats.
 A *predicate* has the form `Predicate(v0, v1, ..., vn)`.
 A *fact* is a *predicate* that does not contain any *variable*.
 A *rule* has the form:
@@ -84,7 +84,8 @@ We will represent the various types as follows:
 - variable: `$v`
 - integer: `12`
 - string: `"hello"`
-- date in RFC 3339 format
+- byte array: `hex:01A2`
+- date in RFC 3339 format: `1985-04-12T23:20:50.52Z`
 
 As an example, assuming we have the following facts: `parent(#a, #b)`,
 `parent(#b, #c)`, `#parent(#c, #d)`. If we apply the rule
@@ -113,6 +114,9 @@ inclusion and set exclusion.
 
 A *string* is a suite of UTF-8 characters. It supports the following
 constraints: prefix, suffix, equal, set inclusion, set exclusion, regular expression.
+
+A *byte array* is a suite of bytes. It supports the following
+constraints: equal, set inclusion, set exclusion.
 
 A *date* is a 64 bit unsigned integer representing a TAI64. It supports the
 following constraints: before, after.

--- a/schema.proto
+++ b/schema.proto
@@ -56,6 +56,7 @@ message ID {
     INTEGER = 2;
     STR = 3;
     DATE = 4;
+    BYTES = 5;
   }
 
   required Kind kind = 1;
@@ -64,6 +65,7 @@ message ID {
   optional int64 integer = 4;
   optional string str = 5;
   optional uint64 date = 6;
+  optional bytes bytes = 7;
 }
 
 message Constraint {
@@ -74,6 +76,7 @@ message Constraint {
     STRING = 1;
     DATE = 2;
     SYMBOL = 3;
+    BYTES = 4;
   }
 
   required Kind kind = 2;
@@ -82,6 +85,7 @@ message Constraint {
   optional StringConstraint str = 4;
   optional DateConstraint date = 5;
   optional SymbolConstraint symbol = 6;
+  optional BytesConstraint bytes = 7;
 }
 
 message IntConstraint {
@@ -150,3 +154,16 @@ message SymbolConstraint {
   repeated uint64 not_in_set = 3;
 }
 
+message BytesConstraint {
+  enum Kind {
+    EQUAL = 0;
+    IN = 1;
+    NOT_IN = 2;
+  }
+
+  required Kind kind = 1;
+
+  optional bytes equal = 2;
+  repeated bytes in_set = 3;
+  repeated bytes not_in_set = 4;
+}


### PR DESCRIPTION
this will be useful to transport arbitrary data in the token without
encoding it in base 64