### PR TITLE
Typo fixes & clarity improvements

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -126,7 +126,6 @@ ancestor("Alice", "Denise")
 
 Interactions with a Datalog program are done through queries: **a query contains
 a rule** that we apply over the system, and **it returns the generated facts**.
->>>>>>> 94e52e1... Typo fixes & clarity improvements
 
 # Datalog in Biscuit
 
@@ -185,7 +184,6 @@ There are two special symbols that can appear in facts:
 
 -`#ambient`: facts that are _provided by the verifier_, and that depend on the **request**, like which resource we want to access(file path, REST endpoint, etc), operation(read, write...), current date and time, source IP address, HTTP headers...
 - `#authority`: facts _defined by the token's original creator_ or _the verifier_, that indicates the basic rights of the **token**. Every new attenation of the token will reduce those rights by adding caveats
->>>>>>> 94e52e1... Typo fixes & clarity improvements
 
 `#ambient` and `#authority` tokens can only be provided by the token's origin
 or by the verifier, **they cannot be added by attenuating the token**.
@@ -218,9 +216,23 @@ Biscuit {
 }
 ```
 
+Let's unpack what's displayed here:
+
+ - `symbols` carries a list of symbols used in the biscuit.
+ - `authority` carries information provided by the token creator. It gives the initial scope of the bicuit.
+ - `blocks` carries a list of blocks, which can refine the scope of the macaroon.
+
+Here, `authority` provides the initial block, which can be refined in subsequent blocks.
+
 A block comes with new symbols it adds to the system (there's a default symbol
 table that already contains values like `#authority` or `#operation`). It can
-contain facts, rules and caveats.
+contain facts, rules and caveats. A block contains:
+
+ - `symbols`:  a block can introduce new symbols: these symbols are available in the current block, _and the following blocks_. **It is not possible to re-declare an existing symbol**.
+ - `context`: free form text used either for documentation purpose, or to give a hind about which facts should be retrieved from DB
+ - `facts`: each block can define new facts (but only `authority` can define facts mentioning `#authority`)
+ - `rules` each block can define new rules (but only `authority` can define rules deriving facts mentioning `#authority`)
+ - `caveats` each block can define new caveats (rules that need to match in order to make the biscuit valid)
 
 Let's assume the user is sending this token with a `PUT /bucket_5678/folder1/hello.txt` HTTP
 request. The verifier would then load the token's facts and rules, along with

--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -14,10 +14,10 @@ remove or replace a block while keeping a valid signature.
 
 Biscuit uses a logic language called [Datalog](https://en.wikipedia.org/wiki/Datalog),
 to represent its authorization rules. It can model and combine authorization policies
-like role based access control or capabilities in a few lines, and even
+like role-based access control or capabilities in a few lines, and even
 have fine grained rules carried by the token.
 As an example, you could have a file server application with a common
-owner or group based access control, in which you could take your token
+owner or group-based access control, in which you could take your token
 and derive a new one, without involving the server, that would be valid
 only for reading a specific file, with an expiration date.
 
@@ -36,6 +36,8 @@ parent("Bob", "Charles")
 parent("Charles", "Denise")
 ```
 
+This means that Alice is Bob's parent, and so on.
+
 This could be seen as a table in a relational database:
 
 | parent |         |         |
@@ -44,7 +46,7 @@ This could be seen as a table in a relational database:
 |        | Bob     | Charles |
 |        | Charles | Denise  |
 
-We can then define rules to create new facts, like this one:
+We can then define rules to create new facts, like this one: (a rule is introduced by the `*` sign, variables are introduced with the `$` sign)
 
 ```
 *grandparent($grandparent, $child) <- parent($grandparent, $parent), parent($parent, $child)
@@ -93,6 +95,7 @@ ancestor("Charles", "Denise")
 ```
 
 Then the second rule could apply as follows:
+
 - `ancestor("Alice", "Charles") <- parent("Alice", "Bob"), ancestor("Bob", "Charles")`
 - `ancestor("Bob", "Denise") <- parent("Bob", "Charles"), ancestor("Charles", "Denise")`
 
@@ -107,16 +110,30 @@ ancestor("Bob", "Denise")
 ```
 
 Then we reapply the second rule:
+
 - `ancestor("Alice", "Denise") <- parent("Alice", "Bob"), ancestor("Bob", "Denise")`
 
-Interactions with a Datalog program are done through queries: a query contains
-a rule that we apply over the system, and it returns the generated facts.
+So in the end we would have:
+
+```
+ancestor("Alice", "Bob")
+ancestor("Bob", "Charles")
+ancestor("Charles", "Denise")
+ancestor("Alice", "Charles")
+ancestor("Bob", "Denise")
+ancestor("Alice", "Denise")
+```
+
+Interactions with a Datalog program are done through queries: **a query contains
+a rule** that we apply over the system, and **it returns the generated facts**.
+>>>>>>> 94e52e1... Typo fixes & clarity improvements
 
 # Datalog in Biscuit
 
 Biscuit comes with a few specific adaptations of Datalog.
 
 It has the following base types (for elements inside of a fact):
+
 - integer (i64)
 - string
 - date (seconds from epoch, UTC)
@@ -125,16 +142,19 @@ It has the following base types (for elements inside of a fact):
 
 Rules can have constraints on fact elements. The following rule will generate
 a fact only if there's a `file` fact and its value starts with `/folder/`:
+
+ 
 `*in_folder($path) <- file($path) @ $path matches /folder/*`
 
 Here are the possible constraints:
+
 - integer: <, >, <=, >=, ==, is in set, is not in set
 - string: prefix, suffix, ==, is in set, is not in set
 - date: before, after
 - symbol: is in set, is not in set
 - byte array: ==, is in set, is not in set
 
-Most of the authorization logic comes with "caveats": they are queries over
+Most of the authorization logic comes with _caveats_: they are queries over
 the Datalog facts and rules. If the query produces something, (if the underlying rule
 generates one or more facts), the caveat is validated, if it does not, the
 caveat fails. For a token verification to be successful, all of the caveats
@@ -148,6 +168,8 @@ using a string constraint:
 *resource_match($path) <- resource(#ambient, $path) @ $path matches /file[0-9]+.txt/
 ```
 
+This rule matches only if `$path` matches a pattern, and if the fact `resource(#ambient, $path)` holds.
+
 In that caveat, the resource fact must have `#ambient` as its first element.
 The `#` character indicates that it is of "symbol" type. There are two special
 symbols that can appear in facts:
@@ -155,12 +177,22 @@ symbols that can appear in facts:
 - `#ambient`: facts that are provided by the verifier, and that depend on the request, like which resource we want to access (file path, REST endpoint, etc), operation (read, write...), current date and time, source IP address, HTTP headers...
 - `#authority`: facts defined by the token's original creator or the verifier, that indicates the basic rights of the token. Every new attenation of the token will reduce those rights by adding caveats
 
+## `#ambient` and `#authority` symbols
+
+This caveat uses a _symbol_ named `#ambient` (symbols start with a `#`).
+
+There are two special symbols that can appear in facts:
+
+-`#ambient`: facts that are _provided by the verifier_, and that depend on the **request**, like which resource we want to access(file path, REST endpoint, etc), operation(read, write...), current date and time, source IP address, HTTP headers...
+- `#authority`: facts _defined by the token's original creator_ or _the verifier_, that indicates the basic rights of the **token**. Every new attenation of the token will reduce those rights by adding caveats
+>>>>>>> 94e52e1... Typo fixes & clarity improvements
+
 `#ambient` and `#authority` tokens can only be provided by the token's origin
-or by the verifier, they cannot be added by attenuating the token.
+or by the verifier, **they cannot be added by attenuating the token**.
 
 # Example tokens
 
-Let's make an example, from an S3 like application, on which we can store and
+Let's make an example, from an S3-like application, on which we can store and
 retrieve files, with users having access to "buckets" holding a list of files.
 
 Here is a first example token, that will hold a user id. This token only
@@ -209,6 +241,7 @@ the current ressource, or extracting the user id from the token with a query.
 
 The verifier can also load its own rules, like creating one specifying rights
 if we own a specific folder:
+
 ```
 right(#authority, $bucket, $path, $operation) <- resource(#ambient, $bucket, $path), operation(#ambient, $operation),
     user_id(#authority, $id), owner(#authority, $id, $bucket)`
@@ -313,6 +346,6 @@ The verifier's caveat would still succeed, but the caveat from block 1 would
 fail because it cannot find `operation(#ambient, #read)`.
 
 By playing with the facts provided on the token and verifier sides, generating
-data through rules, and restricting access with a serie of caveats, it is
+data through rules, and restricting access with a series of caveats, it is
 possible to build powerful rights management systems, with fine grained controls,
-in a mall, cryptographically secured token.
+in a small, cryptographically secured token.


### PR DESCRIPTION
Along with typo fixes, I tried to add explanations everywhere i found things hard to understand

additions I think would be useful

- describing the different fields in the `Biscuit` display (explaining that `authority` is the first block, repeating that each block can declare new facts, symbols (with specific restrictions), etc)
- describing a bit more syntax elements (`@`, `matches`, etc). Is the operations list exhaustive in the types list?
- showing in one place the verifier input (the facts and the rules are listed separately, maybe displaying all the input elements in one place, like for the biscuit itself, would make things clearer?)
- mentioning that variables also introduce symbols

The rule of the last caveat is presented without a leading `*`, is this intentional?

also, are there comments defined in the datalog constraint? 